### PR TITLE
Rename make targets in preparation for upgrade lane

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
-.PHONY: help disable_default_catalog_source update_pull_secret set_imagecontentsourcepolicy deploy_cnv test_cnv all
+.PHONY: help disable_default_catalog_source update_pull_secret set_imagecontentsourcepolicy deploy_cnv upgrade_cnv test_cnv all deploy_test upgrade_test
 
 help:
 	@echo "Run 'make all' to test and deploy $CNV_VERSION/$OCP_VERSION on target cluster"
 	@echo "Use 'make quicklab' to setup target cluster for quicklab"
 
-all: disable_default_catalog_source update_pull_secret set_imagecontentsourcepolicy deploy_cnv test_cnv
+# This target is kept around since it's still being referenced in the openshift/release job configuration.
+# Once the job configuration is modified to run `make deploy_test`, it can be removed.
+all: deploy_cnv
+
+deploy_test: disable_default_catalog_source update_pull_secret set_imagecontentsourcepolicy deploy_cnv test_cnv
+
+upgrade_test: update_pull_secret set_imagecontentsourcepolicy upgrade_cnv test_cnv
 
 disable_default_catalog_source:
 	hack/disable-default-catalog-source.sh
@@ -17,6 +23,9 @@ set_imagecontentsourcepolicy:
 
 deploy_cnv:
 	hack/deploy-cnv.sh
+
+upgrade_cnv:
+	hack/upgrade-cnv.sh
 
 test_cnv:
 	hack/patch-hco-pre-test.sh

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help:
 
 # This target is kept around since it's still being referenced in the openshift/release job configuration.
 # Once the job configuration is modified to run `make deploy_test`, it can be removed.
-all: deploy_cnv
+all: deploy_test
 
 deploy_test: disable_default_catalog_source update_pull_secret set_imagecontentsourcepolicy deploy_cnv test_cnv
 

--- a/hack/upgrade-cnv.sh
+++ b/hack/upgrade-cnv.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "this is a placeholder until the upgrade test lane is implemented


### PR DESCRIPTION
This is a preliminary PR in preparation for the addition of another CI lane to test CNV upgrade.

It adds two "top level" make targets, `make deploy-test` (similar to the existing `make all`) and `make upgrade-test` as a placeholder for the new one.

In parallel, a PR in [openshift/release](https://github.com/openshift/release) will be filed to rename the existing lane's command to `make deploy-test`, as well as to add the new lane.

Once this initial setup is in place and "green", I'll open another PR with the new upgrade test scripts.

Signed-off-by: Zvi Cahana <zvic@il.ibm.com>