### PR TITLE
Update version-mapping.json with recent 4.6/4.7 versions

### DIFF
--- a/version-mapping.json
+++ b/version-mapping.json
@@ -1,10 +1,10 @@
 {
   "4.6": {
-    "index_image": "registry-proxy.engineering.redhat.com/rh-osbs/iib:12345",
-    "bundle_version": "v2.5.0-66"
+    "index_image": "brew.registry.redhat.io/rh-osbs/iib:41080",
+    "bundle_version": "v2.5.4-1"
   },
   "4.7": {
-    "index_image": "registry-proxy.engineering.redhat.com/rh-osbs/iib:31338",
-    "bundle_version": "v2.6.0-355"
+    "index_image": "brew.registry.redhat.io/rh-osbs/iib:41478",
+    "bundle_version": "v2.6.0-515"
   }
 }


### PR DESCRIPTION
Manually updating [`version-mapping.json`](./version-mapping.json) to have recent builds as baseline.
Picked a recent green build from 4.7 branch, and a recent red one from 4.6 (didn't see anything green).

Signed-off-by: Zvi Cahana <zvic@il.ibm.com>