### PR TITLE
Add test script for upgrade lane

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,7 @@ all: deploy_test
 
 deploy_test: disable_default_catalog_source update_pull_secret set_imagecontentsourcepolicy deploy_cnv test_cnv
 
-upgrade_test:
-	true
+upgrade_test: update_pull_secret set_imagecontentsourcepolicy upgrade_cnv test_cnv
 
 disable_default_catalog_source:
 	hack/disable-default-catalog-source.sh

--- a/hack/create_brew_catalogsource.sh
+++ b/hack/create_brew_catalogsource.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+eval "$(jq -r '."'"$OCP_VERSION"'" | to_entries[] | .key+"="+.value' version-mapping.json)"
+
+echo "creating brew catalog source"
+oc create -f - <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: brew-catalog-source
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: $index_image
+  displayName: Brew Catalog Source
+  publisher: grpc
+EOF
+
+while [ "$(oc get pods -n "openshift-marketplace" -l olm.catalogSource="brew-catalog-source" --no-headers | wc -l)" -eq 0 ]; do
+    echo "waiting for catalog source pod to be created"
+    sleep 5
+done
+
+echo "waiting for catalog source pod to be ready"
+oc wait pods -n "openshift-marketplace" -l olm.catalogSource="brew-catalog-source" --for condition=Ready --timeout=180s

--- a/hack/upgrade-cnv.sh
+++ b/hack/upgrade-cnv.sh
@@ -1,3 +1,104 @@
 #!/usr/bin/env bash
 
-echo "this is a placeholder until the upgrade test lane is implemented"
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+echo "OCP_VERSION: $OCP_VERSION"
+
+eval "$(jq -r '."'"$OCP_VERSION"'" | to_entries[] | .key+"="+.value' version-mapping.json)"
+
+# These variables are set when the eval above is executed
+# shellcheck disable=SC2154
+echo "Using index_image: $index_image"
+# shellcheck disable=SC2154
+echo "Using bundle_version: $bundle_version"
+
+#==========================================
+# Deploy HCO using latest released version
+#==========================================
+
+echo "creating $TARGET_NAMESPACE namespace"
+oc create ns $TARGET_NAMESPACE
+
+echo "creating operator group"
+oc create -f - <<EOF
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-cnv-group
+  namespace: $TARGET_NAMESPACE
+spec:
+  targetNamespaces:
+  - $TARGET_NAMESPACE
+EOF
+
+echo "installing kubevirt-hyperconverged using latest stable release"
+
+echo "creating subscription"
+oc create -f - <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kubevirt-hyperconverged
+  namespace: $TARGET_NAMESPACE
+  labels:
+    operators.coreos.com/kubevirt-hyperconverged.openshift-cnv: ''
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: kubevirt-hyperconverged
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+EOF
+
+echo "waiting for HyperConverged operator to become ready"
+$SCRIPT_DIR/wait_for_hco.sh
+
+#=======================================
+# Upgrade HCO to latest build from brew
+#=======================================
+
+OLD_CSV=$(oc get subscription kubevirt-hyperconverged -n $TARGET_NAMESPACE -o jsonpath="{.status.installedCSV}")
+
+while [ $(oc get ClusterServiceVersion $OLD_CSV -n $TARGET_NAMESPACE -o jsonpath="{.status.phase}") != "Succeeded" ]; do
+	echo "waiting for the previous CSV installation to complete"
+	sleep 10
+done
+
+echo "setting up brew catalog source"
+$SCRIPT_DIR/create_brew_catalogsource.sh
+
+echo "patching the subscription to switch to the brew catalog source"
+oc patch subscription kubevirt-hyperconverged -n $TARGET_NAMESPACE --type=merge --patch='{"spec": {"source": "brew-catalog-source"}}'
+
+echo "waiting for the new CSV installation to commence"
+sleep 60
+
+echo "waiting for the subscription's currentCSV to move to the new catalog source"
+while true; do
+  CURRENT_CSV=$(oc get subscription kubevirt-hyperconverged -n $TARGET_NAMESPACE -o jsonpath="{.status.currentCSV}")
+  if [ "$CURRENT_CSV" != "$OLD_CSV"]; then
+    NEW_CSV=$CURRENT_CSV
+    break
+  fi
+
+  echo "waiting for the subscription's currentCSV to move to the new catalog source"
+  sleep 10
+done
+
+echo "waiting for HyperConverged operator to become ready"
+$SCRIPT_DIR/wait_for_hco.sh
+
+echo "waiting for the subscription's installedCSV to move to the new catalog source"
+while true; do
+  INSTALLED_CSV=$(oc get subscription kubevirt-hyperconverged -n $TARGET_NAMESPACE -o jsonpath="{.status.installedCSV}")
+  if [ "$INSTALLED_CSV" = "$CURRENT_CSV" ]; then
+    break
+  fi
+
+  echo "waiting for the subscription's installedCSV to move to the new catalog source"
+  sleep 30
+done
+
+echo "HyperConverged operator upgrade successfully completed"

--- a/hack/wait_for_hco.sh
+++ b/hack/wait_for_hco.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+#
+echo "waiting for operator pods to be created"
+while [ "$(oc get pods -n "${TARGET_NAMESPACE}" --no-headers | wc -l)" -lt 5 ]; do
+    sleep 5
+done
+
+counter=3
+for i in $(seq 1 $counter); do
+    echo "waiting for operator pods to be ready (try $i)"
+    oc wait pods -n "${TARGET_NAMESPACE}" --all --for condition=Ready --timeout=10m && break
+    sleep 5
+done
+
+echo "waiting for hco-operator and hco-webhook to be ready"
+oc wait deployment hco-operator hco-webhook --for condition=Available -n "${TARGET_NAMESPACE}" --timeout="20m"
+
+# Wait a few more seconds for the hco-webhook Service and Endpoints objects
+# to be updated and propagated through the system, to prevent connection errors to the webhook.
+sleep 20s
+
+echo "waiting for HyperConverged operator CRD to be created"
+while [ "$(oc get crd -n "${TARGET_NAMESPACE}" hyperconvergeds.hco.kubevirt.io --no-headers | wc -l)" -eq 0 ]; do
+    sleep 5
+done
+
+echo "checking if HyperConverged operator CR already exists"
+if [ "$(oc get HyperConverged kubevirt-hyperconverged -n "${TARGET_NAMESPACE}" --no-headers | wc -l)" -eq 0 ]; then
+
+	echo "creating HyperConverged operator CR"
+	
+	oc create -f - <<EOF
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+  namespace: "${TARGET_NAMESPACE}"
+spec:
+  BareMetalPlatform: true
+EOF
+
+fi
+
+echo "waiting for HyperConverged operator to be available"
+oc wait -n "${TARGET_NAMESPACE}" HyperConverged kubevirt-hyperconverged --for condition=Available --timeout=20m


### PR DESCRIPTION
This first implementation is just a deployment of CNV at its latest released version, followed by an upgrade to the latest downstream build from brew, followed by a smoke test (the same one that runs at deploy-test).

Later on, this should be extended such that a VM workload is started before the upgrade, and a smoke test is executed on that workload after the upgrade, to verify that it's still in tact.