### PR TITLE
Align test setup to versions regarding configmap

### DIFF
--- a/hack/deploy-cnv.sh
+++ b/hack/deploy-cnv.sh
@@ -98,5 +98,10 @@ spec:
   BareMetalPlatform: true
 EOF
 
+if [[ "${KUBEVIRT_RELEASE}" =~ 0.34 ]]; then
+    echo "creating KubeVirt config map"
+    oc create -f "https://storage.googleapis.com/kubevirt-prow/devel/release/kubevirt/kubevirt/v0.34.2/manifests/testing/kubevirt-config.yaml"
+fi
+
 echo "waiting for HyperConverged operator to be available"
 oc wait -n "${TARGET_NAMESPACE}" HyperConverged kubevirt-hyperconverged --for condition=Available --timeout=20m

--- a/hack/patch-hco-pre-test.sh
+++ b/hack/patch-hco-pre-test.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [[ "${KUBEVIRT_RELEASE}" =~ 0.34 ]]; then
+    echo "Skipping scaling down the hco-operator pod due to older version"
+    return
+fi
+
 set -euo pipefail
 
 echo "scale down hco-operator, as it's still using the config map for KubeVirt"


### PR DESCRIPTION
For 0.34 skip scaling down hco pod, and create configmap.

/cc @zcahana 