### PR TITLE
Fix several test issues

### DIFF
--- a/hack/patch-hco-pre-test.sh
+++ b/hack/patch-hco-pre-test.sh
@@ -2,7 +2,7 @@
 
 if [[ "${KUBEVIRT_RELEASE}" =~ 0.34 ]]; then
     echo "Skipping scaling down the hco-operator pod due to older version"
-    return
+    exit 0
 fi
 
 set -euxo pipefail

--- a/hack/upgrade-cnv.sh
+++ b/hack/upgrade-cnv.sh
@@ -85,7 +85,7 @@ $SCRIPT_DIR/retry.sh 60 10 "oc get subscription kubevirt-hyperconverged -n $TARG
 # this will be resolved in kubectl v1.21: https://github.com/kubernetes/kubernetes/pull/96702
 # till then, we manually test for 404 in the output string (both with v1.20 and pre-v.120 formats)
 echo "waiting for the previous CSV to be completely removed"
-WAIT_CSV_OUTPUT=$(oc wait ClusterServiceVersion $OLD_CSV -n $TARGET_NAMESPACE --for delete --timeout=10m 2>&1)
+WAIT_CSV_OUTPUT=$(oc wait ClusterServiceVersion $OLD_CSV -n $TARGET_NAMESPACE --for delete --timeout=20m 2>&1)
 if [ $? -ne 0 ] && ! grep -qE "NotFound|(no matching resources found)" <(echo "$WAIT_CSV_OUTPUT"); then
   echo "$WAIT_CSV_OUTPUT"
   exit 1

--- a/hack/wait-for-hco.sh
+++ b/hack/wait-for-hco.sh
@@ -37,18 +37,5 @@ EOF
 
 fi
 
-if [[ "$KUBEVIRT_RELEASE" =~ 0.34 ]]; then
-  echo "checking KubeVirt config map already exists"
-  if [ "$(oc get ConfigMap kubevirt-config -n $TARGET_NAMESPACE --no-headers | wc -l)" -eq 0 ]; then
-    echo "creating KubeVirt config map"
-
-    KUBEVIRT_CONFIG_FILE="kubevirt-config.yaml"
-    curl -Lo $KUBEVIRT_CONFIG_FILE "https://storage.googleapis.com/kubevirt-prow/devel/release/kubevirt/kubevirt/$KUBEVIRT_RELEASE/manifests/testing/kubevirt-config.yaml"
-    sed -i "s/namespace: kubevirt/namespace: $TARGET_NAMESPACE/" $KUBEVIRT_CONFIG_FILE
-
-    oc create -f $KUBEVIRT_CONFIG_FILE
-  fi
-fi
-
 echo "waiting for HyperConverged operator to be available"
 oc wait HyperConverged kubevirt-hyperconverged -n $TARGET_NAMESPACE --for condition=Available --timeout=30m

--- a/hack/wait-for-hco.sh
+++ b/hack/wait-for-hco.sh
@@ -21,7 +21,7 @@ echo "waiting for HyperConverged operator CRD to be created"
 $SCRIPT_DIR/retry.sh 30 10 "oc get crd hyperconvergeds.hco.kubevirt.io"
 
 echo "checking if HyperConverged operator CR already exists"
-if [ "$(oc get HyperConverged kubevirt-hyperconverged -n "${TARGET_NAMESPACE}" --no-headers | wc -l)" -eq 0 ]; then
+if [ "$(oc get HyperConverged kubevirt-hyperconverged -n $TARGET_NAMESPACE --no-headers | wc -l)" -eq 0 ]; then
 
 	echo "creating HyperConverged operator CR"
 	
@@ -30,18 +30,23 @@ apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged
-  namespace: "${TARGET_NAMESPACE}"
+  namespace: $TARGET_NAMESPACE
 spec:
   BareMetalPlatform: true
 EOF
 
 fi
 
-if [[ "${KUBEVIRT_RELEASE}" =~ 0.34 ]]; then
+if [[ "$KUBEVIRT_RELEASE" =~ 0.34 ]]; then
   echo "checking KubeVirt config map already exists"
-  if [ "$(oc get ConfigMap kubevirt-config -n "${TARGET_NAMESPACE}" --no-headers | wc -l)" -eq 0 ]; then
+  if [ "$(oc get ConfigMap kubevirt-config -n $TARGET_NAMESPACE --no-headers | wc -l)" -eq 0 ]; then
     echo "creating KubeVirt config map"
-    oc create -n "${TARGET_NAMESPACE}" -f "https://storage.googleapis.com/kubevirt-prow/devel/release/kubevirt/kubevirt/v0.34.2/manifests/testing/kubevirt-config.yaml"
+
+    KUBEVIRT_CONFIG_FILE="kubevirt-config.yaml"
+    curl -Lo $KUBEVIRT_CONFIG_FILE "https://storage.googleapis.com/kubevirt-prow/devel/release/kubevirt/kubevirt/$KUBEVIRT_RELEASE/manifests/testing/kubevirt-config.yaml"
+    sed -i "s/namespace: kubevirt/namespace: $TARGET_NAMESPACE/" $KUBEVIRT_CONFIG_FILE
+
+    oc create -f $KUBEVIRT_CONFIG_FILE
   fi
 fi
 

--- a/version-mapping.json
+++ b/version-mapping.json
@@ -1,14 +1,14 @@
 {
   "4.6": {
-    "index_image": "brew.registry.redhat.io/rh-osbs/iib:45911",
-    "bundle_version": "v2.5.4-57"
+    "index_image": "brew.registry.redhat.io/rh-osbs/iib:48611",
+    "bundle_version": "v2.5.5-18"
   },
   "4.7": {
-    "index_image": "brew.registry.redhat.io/rh-osbs/iib:45947",
-    "bundle_version": "v2.6.0-570"
+    "index_image": "brew.registry.redhat.io/rh-osbs/iib:48477",
+    "bundle_version": "v2.6.0-618"
   },
   "4.8": {
-    "index_image": "brew.registry.redhat.io/rh-osbs/iib:45947",
-    "bundle_version": "v2.6.0-570"
+    "index_image": "brew.registry.redhat.io/rh-osbs/iib:48477",
+    "bundle_version": "v2.6.0-618"
   }
 }


### PR DESCRIPTION
This PR fixes several issues with the tests:
1. Removes the manual `kubevirt-config` ConfigMap creation that was introduced in #22. This is eventually not needed as the ConfigMap is created by HCO.
2. Increase the timeout in waiting for the old CSV to be removed in the upgrade test.
3. Fixes a script syntax problem that caused HCO to be scaled to 0 in 4.6 tests.

/assign @dhiller 

Signed-off-by: Zvi Cahana <zvic@il.ibm.com>