### PR TITLE
[release-4.8] Upgrade with a running VM

### DIFF
--- a/hack/Dockerfile.upgrade.src.ci
+++ b/hack/Dockerfile.upgrade.src.ci
@@ -1,0 +1,5 @@
+FROM src
+
+RUN yum install -y expect
+COPY oc /usr/bin/oc
+

--- a/hack/vm.yaml
+++ b/hack/vm.yaml
@@ -1,0 +1,37 @@
+apiVersion: kubevirt.io/v1alpha3
+kind: VirtualMachine
+metadata:
+  name: testvm
+spec:
+  running: false
+  template:
+    metadata:
+      labels:
+        kubevirt.io/size: small
+        kubevirt.io/domain: testvm
+    spec:
+      domain:
+        devices:
+          disks:
+            - name: containerdisk
+              disk:
+                bus: virtio
+            - name: cloudinitdisk
+              disk:
+                bus: virtio
+          interfaces:
+          - name: default
+            masquerade: {}
+        resources:
+          requests:
+            memory: 64M
+      networks:
+      - name: default
+        pod: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            image: quay.io/kubevirt/cirros-container-disk-demo
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            userDataBase64: SGkuXG4=

--- a/hack/vmuptime.ext
+++ b/hack/vmuptime.ext
@@ -1,0 +1,20 @@
+#!/usr/bin/expect -f
+
+# Wait enough (forever) until a long-time boot
+set timeout -1
+
+# Start the guest VM
+spawn ~/virtctl console testvm -n vmsns
+
+send "\n"
+expect "login: "
+send "cirros\n"
+
+expect "Password: "
+send "gocubsgo\n"
+
+expect "$ "
+send "echo BOOTTIME=\$((\$(date +%s) - \$(awk '{print int(\$1)}' /proc/uptime)))\n"
+
+expect "$ "
+send "exit"


### PR DESCRIPTION
- Start a VM before the upgrade and check that it's
still running after the upgrade at VMI level.
- Prepare the infrastructure to check the real uptime at
guest level using expect via virtctl console.