### PR TITLE
Add Flake Attempts to GinkGo Test Suite

### DIFF
--- a/hack/test-cnv.sh
+++ b/hack/test-cnv.sh
@@ -89,4 +89,5 @@ ${TESTS_BINARY} \
     -kubectl-path="$(which oc)" \
     -utility-container-prefix=quay.io/kubevirt \
     -test.timeout=2h \
+    -ginkgo.flake-attempts=3 \
     "${skip_arg}"


### PR DESCRIPTION
> If a test fails, Gingko can rerun it immediately.
> As long as one of the retries succeeds, Ginkgo will not consider the test suite to have been failed. The individual failed runs will still be reported in the output; the JUnit output, for example, will claim 0 failures (since the suite passed) but will still contain any failing runs for a test that both passed and failed.
https://onsi.github.io/ginkgo/

Signed-off-by: orenc1 <ocohen@redhat.com>