### PR TITLE
Add retries for VM boot time extraction

### DIFF
--- a/hack/check-uptime.sh
+++ b/hack/check-uptime.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+function check_uptime() {
+  retries=$1
+  timeout=$2
+
+  for _ in seq 1 $retries; do
+    BOOTTIME=$(./hack/vmuptime.ext | grep "^BOOTTIME" | cut -d= -f2 | tr -dc '[:digit:]')
+    if [ -n "${BOOTTIME}" ]
+      then
+        echo "${BOOTTIME}"
+        return 0;
+      else
+        sleep $timeout;
+    fi
+  done;
+  echo "VM boot time could not be retrieved"
+  return 1;
+}

--- a/hack/upgrade-cnv.sh
+++ b/hack/upgrade-cnv.sh
@@ -123,7 +123,8 @@ oc get vm -n ${VMS_NAMESPACE} -o yaml testvm
 "$SCRIPT_DIR"/retry.sh 30 10 "oc get vmi -n ${VMS_NAMESPACE} testvm -o jsonpath='{ .status.phase }' | grep 'Running'"
 oc get vmi -n ${VMS_NAMESPACE} -o yaml testvm
 
-INITIAL_BOOTTIME=$(./hack/vmuptime.ext | grep "^BOOTTIME" | cut -d= -f2 | tr -dc '[:digit:]')
+source ./hack/check-uptime.sh
+INITIAL_BOOTTIME=$(check_uptime 10 60)
 
 #=======================================
 # Upgrade HCO to latest build from brew
@@ -189,7 +190,7 @@ oc get vm -n "${VMS_NAMESPACE}" -o yaml testvm
 oc get vmi -n "${VMS_NAMESPACE}" -o yaml testvm
 oc get vmi -n "${VMS_NAMESPACE}" testvm -o jsonpath='{ .status.phase }' | grep 'Running'
 
-CURRENT_BOOTTIME=$(./hack/vmuptime.ext | grep "^BOOTTIME" | cut -d= -f2 | tr -dc '[:digit:]')
+CURRENT_BOOTTIME=$(check_uptime 10 60)
 
 if ((INITIAL_BOOTTIME - CURRENT_BOOTTIME > 3)) || ((CURRENT_BOOTTIME - INITIAL_BOOTTIME > 3)); then
     echo "ERROR: The test VM got restarted during the upgrade process."

--- a/hack/vmuptime.ext
+++ b/hack/vmuptime.ext
@@ -1,7 +1,7 @@
 #!/usr/bin/expect -f
 
-# Wait enough (forever) until a long-time boot
-set timeout -1
+# Wait 60 seconds to get the boot time output from the VM
+set timeout 60
 
 # Start the guest VM
 spawn ~/virtctl console testvm -n vmsns


### PR DESCRIPTION
The test that checks that the VM was not rebooted during CNV upgrade is often stuck and fails the entire job.
This PR is setting a timeout of 60 seconds for the `expect` script, and it is getting retried if the boot time could not be extracted in time.

Signed-off-by: orenc1 <ocohen@redhat.com>