### PR TITLE
Add pod security labels to fix failing cnv CI jobs

### DIFF
--- a/hack/deploy-cnv.sh
+++ b/hack/deploy-cnv.sh
@@ -21,6 +21,14 @@ echo "OCP_VERSION: $OCP_VERSION"
 
 oc create ns "${TARGET_NAMESPACE}"
 
+# add pod security admission labels
+oc label namespace "${TARGET_NAMESPACE}" pod-security.kubernetes.io/enforce=privileged
+oc label namespace "${TARGET_NAMESPACE}" pod-security.kubernetes.io/audit=privileged
+oc label namespace "${TARGET_NAMESPACE}" pod-security.kubernetes.io/warn=privileged
+# shouldn't be needed for openshift- prefixed namespaces but add in case TARGET_NAMESPACE is non openshift- prefix
+oc label namespace "${TARGET_NAMESPACE}" security.openshift.io/scc.podSecurityLabelSync=false
+
+
 if [ "$PRODUCTION_RELEASE" = "true" ]; then
     echo "creating subscription"
     oc create -f - <<EOF


### PR DESCRIPTION
TRT is tracking down failed jobs / tests caused by the recent [Pod Security Admission changes](https://docs.openshift.com/container-platform/4.11/authentication/understanding-and-managing-pod-security-admission.html).

[A search](https://search.ci.openshift.org/?search=forbidden%3A+violates+PodSecurity&maxAge=336h&context=1&type=build-log&name=.*cnv&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job) turns up cnv test failures with:

` em:serviceaccount:kube-system:replicaset-controller","objectRef":{"resource":"pods","namespace":"openshift-cnv","apiVersion":"v1"},"responseStatus":{"metadata":{},"status":"Failure","message":"pods \"cdi-deployment-75d5678f4d-k5lp7\" is forbidden: violates PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (container \"cdi-controller\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities ... `
  
  `"em:serviceaccount:kube-system:replicaset-controller","objectRef":{"resource":"pods","namespace":"openshift-cnv","apiVersion":"v1"},"responseStatus":{"metadata":{},"status":"Failure","message":"pods \"cluster-network-addons-operator-765f56b5bf-8jb67\" is forbidden: violates PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (containers \"cluster-network-addons-operator\", \"kube-rbac-proxy\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities ...  `
  
  This fix attempts to raise awareness of those failures and address the issue.