### PR TITLE
Use apply instead of create

### DIFF
--- a/hack/set-imagecontentsourcepolicy.sh
+++ b/hack/set-imagecontentsourcepolicy.sh
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 echo "creating imageContentSourcePolicy"
-oc create -f - <<EOF
+oc apply -f - <<EOF
 apiVersion: operator.openshift.io/v1alpha1
 kind: ImageContentSourcePolicy
 metadata:

--- a/hack/set-imagecontentsourcepolicy.sh
+++ b/hack/set-imagecontentsourcepolicy.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-echo "creating imageContentSourcePolicy"
+echo "applying imageContentSourcePolicy"
 oc apply -f - <<EOF
 apiVersion: operator.openshift.io/v1alpha1
 kind: ImageContentSourcePolicy


### PR DESCRIPTION
This should allow the code to run if we already have applied the ICSP in a different stage (like in other workflows).

Signed-off-by: Rabin Yasharzadehe <rabin@rabin.io>
