### PR TITLE
[4.10 Backport] Use apply instead of create

### DIFF
--- a/hack/set-imagecontentsourcepolicy.sh
+++ b/hack/set-imagecontentsourcepolicy.sh
@@ -2,8 +2,8 @@
 
 set -euxo pipefail
 
-echo "creating imageContentSourcePolicy"
-oc create -f - <<EOF
+echo "applying imageContentSourcePolicy"
+oc apply -f - <<EOF
 apiVersion: operator.openshift.io/v1alpha1
 kind: ImageContentSourcePolicy
 metadata:


### PR DESCRIPTION
This should allow the code to run if we already have applied the ICSP in a different stage (like in other workflows).

Signed-off-by: Rabin Yasharzadehe <rabin@rabin.io>
