### PR TITLE
Increase mcp wait timeout to 15m

### DIFF
--- a/hack/set-imagecontentsourcepolicy.sh
+++ b/hack/set-imagecontentsourcepolicy.sh
@@ -22,7 +22,7 @@ spec:
 EOF
 
 echo "waiting for update to start"
-oc wait mcp --all --for condition=updating --timeout=5m
+oc wait mcp --all --for condition=updating --timeout=15m
 
 counter=3
 set +e


### PR DESCRIPTION
Sometimes it takes more time, 

```
 + oc wait mcp --all --for condition=updating --timeout=5m
machineconfigpool.machineconfiguration.openshift.io/master condition met
error: timed out waiting for the condition on machineconfigpools/worker
make: *** [set_imagecontentsourcepolicy] Error 1
{"component":"entrypoint","error":"wrapped process failed: exit status 2","file":"k8s.io/test-infra/prow/entrypoint/run.go:84","func":"k8s.io/test-infra/prow/entrypoint.Options.internalRun","level":"error","msg":"Error executing test process","severity":"error","time":"2023-10-23T08:27:24Z"}
error: failed to execute wrapped command: exit status 2
```