### PR TITLE
Bump utility container tags

### DIFF
--- a/hack/test-cnv.sh
+++ b/hack/test-cnv.sh
@@ -152,5 +152,6 @@ ${TESTS_BINARY} \
     -utility-container-prefix=quay.io/kubevirt \
     -test.timeout=3h \
     -test.v \
+    -utility-container-tag="${UTILITY_CONTAINER_TAG:-v1.4.0}" \
     "${GINKGO_FLAKE}" \
     "${skip_arg}"


### PR DESCRIPTION
The latest tags in several images used for testing are outdated and not multi-arch. This commit bumps the utility container tag value to v1.4.0.
For example, https://quay.io/repository/kubevirt/fedora-with-test-tooling-container-disk will default to `latest` if this parameter is not set. `latest` was updated 3y ago and is not multi-arch, leading tests on arm64 to fail.

Refers:
 - https://github.com/kubevirt/kubevirt/blob/5c05ef0efd76ffbd7286c17086ae1a51602ddcf7/tests/flags/flags.go#L67-L69
 - https://github.com/kubevirt/kubevirt/blob/90b00f44a50d2d06bf292b3892d5c49e8a3a22c8/tests/containerdisk/containerdisk.go#L63-L73

Blocks openshift/release#58544