### PR TITLE
Rebuild cnv-ci-src 4.16 image

### DIFF
--- a/hack/test-cnv.sh
+++ b/hack/test-cnv.sh
@@ -137,7 +137,7 @@ else
   GINKGO_SLOW="--ginkgo.slow-spec-threshold=60s"
 fi
 
-
+cat /etc/os-release
 echo "Starting tests 🧪"
 ${TESTS_BINARY} \
     -cdi-namespace="$TARGET_NAMESPACE" \


### PR DESCRIPTION
After merging https://github.com/openshift/release/pull/60641,
rebuild it to make it use an updated base image of golang-1.22