### PR TITLE
[release-4.18] Change ARTIFACT_DIR to ARTIFACTS

### DIFF
--- a/hack/dump-state.sh
+++ b/hack/dump-state.sh
@@ -37,18 +37,19 @@ cat <<EOF
 =================================
 EOF
 
-if [ -n "${ARTIFACT_DIR}" ]; then
+export ARTIFACTS="${ARTIFACT_DIR}"
+if [ -n "${ARTIFACTS}" ]; then
     cat <<EOF
 ==============================
 executing cnv-must-gather
 ==============================
 
 EOF
-    mkdir -p ${ARTIFACT_DIR}/cnv-must-gather
-    mkdir -p ${ARTIFACT_DIR}/cnv-must-gather-vms
+    mkdir -p ${ARTIFACTS}/cnv-must-gather
+    mkdir -p ${ARTIFACTS}/cnv-must-gather-vms
     CNV_MG_IMAGE=$(${CMD} get csv -n openshift-cnv -o json | jq -r '.items[0].spec.relatedImages[] | select (.name | contains("must-gather")) | .image')
-    RunCmd "${CMD} adm must-gather --image=${CNV_MG_IMAGE} --dest-dir=${ARTIFACT_DIR}/cnv-must-gather --timeout='30m'"
-    RunCmd "${CMD} adm must-gather --image=${CNV_MG_IMAGE} --dest-dir=${ARTIFACT_DIR}/cnv-must-gather-vms --timeout='30m' -- /usr/bin/gather --vms_details"
+    RunCmd "${CMD} adm must-gather --image=${CNV_MG_IMAGE} --dest-dir=${ARTIFACTS}/cnv-must-gather --timeout='30m'"
+    RunCmd "${CMD} adm must-gather --image=${CNV_MG_IMAGE} --dest-dir=${ARTIFACTS}/cnv-must-gather-vms --timeout='30m' -- /usr/bin/gather --vms_details"
 fi
 
 cat <<EOF

--- a/hack/test-cnv.sh
+++ b/hack/test-cnv.sh
@@ -122,8 +122,8 @@ skip_tests+=('Prometheus Endpoints')
 skip_regex=$(printf '(%s)|' "${skip_tests[@]}")
 skip_arg=$(printf -- '--ginkgo.skip=%s' "${skip_regex:0:-1}")
 
-
-mkdir -p "${ARTIFACT_DIR}"
+export ARTIFACTS="${ARTIFACT_DIR}"
+mkdir -p "${ARTIFACTS}"
 
 if [[ "$OCP_VERSION" == "4.10" ]];
 then
@@ -142,7 +142,7 @@ ${TESTS_BINARY} \
     -cdi-namespace="$TARGET_NAMESPACE" \
     -config="./manifests/testing/${KUBEVIRT_TESTING_CONFIGURATION_FILE}" \
     -installed-namespace="$TARGET_NAMESPACE" \
-    -junit-output="${ARTIFACT_DIR}/junit.functest.xml" \
+    -junit-output="${ARTIFACTS}/junit.functest.xml" \
     -kubeconfig="$KUBECONFIG" \
     -ginkgo.focus='(rfe_id:1177)|(rfe_id:273)|(rfe_id:151)' \
     "${GINKGO_NOCOLOR}" \


### PR DESCRIPTION
This is in order to enable storing of kubevirt test suite artifacts during tests run.