### PR TITLE
fix(OWNERS): move approvers to emeritus

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,16 +1,14 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-- dhiller
 - fabiand
-- fgimenez
 - orenc1
-- rmohr
 - tiraboschi
 reviewers:
-- dhiller
 - fabiand
-- fgimenez
 - orenc1
-- rmohr
 - tiraboschi
+emeritus_approvers:
+- dhiller
+- rmohr
+- fgimenez


### PR DESCRIPTION
Since @dhiller, @rmohr and @fgimenez aren't active on this repository as contributors, move them to the emeritus section as documented [1]

[1]: https://www.kubernetes.dev/docs/guide/owners/#emeritus