### PR TITLE
[4.20] add `jq` to the test image

### DIFF
--- a/hack/Dockerfile.test.src.ci
+++ b/hack/Dockerfile.test.src.ci
@@ -1,0 +1,5 @@
+FROM src
+
+RUN dnf update -y \
+    && dnf install -y jq \
+    && dnf clean all


### PR DESCRIPTION
check if the CI lanes are running and the 4.20 images are present.