### PR TITLE
Backport missing changes from release-4.20 branch

### DIFF
--- a/hack/Dockerfile.test.src.ci
+++ b/hack/Dockerfile.test.src.ci
@@ -1,0 +1,5 @@
+FROM src
+
+RUN dnf update -y \
+    && dnf install -y jq \
+    && dnf clean all

--- a/hack/Dockerfile.upgrade.src.ci
+++ b/hack/Dockerfile.upgrade.src.ci
@@ -1,7 +1,7 @@
 FROM src
 
 RUN dnf install -y --nodocs --setopt=install_weak_deps=False \
-    expect sqlite \
+    expect sqlite jq \
     && dnf clean all \
     && rm -rfv \
         /var/cache/dnf \

--- a/hack/test-cnv-arm64.sh
+++ b/hack/test-cnv-arm64.sh
@@ -14,10 +14,10 @@ if [ "$PRODUCTION_RELEASE" = "false" ]; then
 fi
 KUBEVIRT_TAG=$(oc image info -a /tmp/authfile.new ${VIRT_OPERATOR_IMAGE} -o json --filter-by-os=linux/amd64 | jq '.config.config.Labels["upstream-version"]')
 KUBEVIRT_RELEASE=v$(echo ${KUBEVIRT_TAG} | awk -F '-' '{print $1}' | tr -d '"')
-if [[ ${KUBEVIRT_TAG} == *"rc"* ]] || [[ ${KUBEVIRT_TAG} == *"alpha"* ]]; then
+if [[ ${KUBEVIRT_TAG} == *"rc"* ]] || [[ ${KUBEVIRT_TAG} == *"alpha"* ]] || [[ ${KUBEVIRT_TAG} == *"beta"* ]]; then
   KUBEVIRT_TESTS_URL=https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_RELEASE}/tests.test
   if ! curl --output /dev/null --silent --head --fail "${KUBEVIRT_TESTS_URL}"; then
-    # First checking if the official release exists (without "rc" or "alpha"). If not - use the release candidate version.
+    # First checking if the official release exists (without "rc", "alpha" or "beta"). If not - use the release candidate version.
     KUBEVIRT_RELEASE=v$(echo ${KUBEVIRT_TAG} | awk -F '-' '{print $1"-"$2}' | tr -d '"')
   fi
 fi
@@ -78,7 +78,6 @@ ${TESTS_BINARY} \
     -ginkgo.seed=0 \
     -ginkgo.v \
     -ginkgo.trace \
-    -oc-path="$(which oc)" \
     -kubectl-path="$(which oc)" \
     -utility-container-prefix=quay.io/kubevirt \
     -test.timeout=3h \

--- a/hack/test-cnv.sh
+++ b/hack/test-cnv.sh
@@ -14,10 +14,10 @@ if [ "$PRODUCTION_RELEASE" = "false" ]; then
 fi
 KUBEVIRT_TAG=$(oc image info -a /tmp/authfile.new ${VIRT_OPERATOR_IMAGE} -o json --filter-by-os=linux/amd64 | jq '.config.config.Labels["upstream-version"]')
 KUBEVIRT_RELEASE=v$(echo ${KUBEVIRT_TAG} | awk -F '-' '{print $1}' | tr -d '"')
-if [[ ${KUBEVIRT_TAG} == *"rc"* ]] || [[ ${KUBEVIRT_TAG} == *"alpha"* ]]; then
+if [[ ${KUBEVIRT_TAG} == *"rc"* ]] || [[ ${KUBEVIRT_TAG} == *"alpha"* ]] || [[ ${KUBEVIRT_TAG} == *"beta"* ]]; then
   KUBEVIRT_TESTS_URL=https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_RELEASE}/tests.test
   if ! curl --output /dev/null --silent --head --fail "${KUBEVIRT_TESTS_URL}"; then
-    # First checking if the official release exists (without "rc" or "alpha"). If not - use the release candidate version.
+    # First checking if the official release exists (without "rc", "alpha" or "beta"). If not - use the release candidate version.
     KUBEVIRT_RELEASE=v$(echo ${KUBEVIRT_TAG} | awk -F '-' '{print $1"-"$2}' | tr -d '"')
   fi
 fi
@@ -150,7 +150,6 @@ ${TESTS_BINARY} \
     "${GINKGO_SLOW}" \
     -ginkgo.v \
     -ginkgo.trace \
-    -oc-path="$(which oc)" \
     -kubectl-path="$(which oc)" \
     -utility-container-prefix=quay.io/kubevirt \
     -test.timeout=3h \

--- a/manifests/testing/kubevirt-testing-infra.yaml
+++ b/manifests/testing/kubevirt-testing-infra.yaml
@@ -50,7 +50,7 @@ spec:
       serviceAccountName: kubevirt-testing
       containers:
         - name: target
-          image: quay.io/kubevirt/disks-images-provider:v1.4.0
+          image: quay.io/kubevirt/disks-images-provider:v1.6.0-beta.0
           imagePullPolicy: Always
           env:
             - name: NUM_TEST_IMAGE_REPLICAS
@@ -65,6 +65,7 @@ spec:
             mountPropagation: Bidirectional
           securityContext:
             privileged: true
+            readOnlyRootFilesystem: false
           readinessProbe:
             exec:
               command:


### PR DESCRIPTION
* [4.20] Add jq to the test image

Signed-off-by: Oren Cohen <ocohen@redhat.com>

(cherry picked from commit 481e26fe4f5027d330f5b7ba01f9c900888f9d83)

* add jq to upgrade.src.ci image

Signed-off-by: Oren Cohen <ocohen@redhat.com>

(cherry picked from commit 43792c421a490e29819127915bc851f865f0b9cb)

* disks-images-provider: set readOnlyRootFilesystem to false

Signed-off-by: Oren Cohen <ocohen@redhat.com>

(cherry picked from commit 23016a5f3ab8e8d00e7196dd9bea7f10bf287f71)

* Use also beta tags for KUBEVIRT_RELEASE

Signed-off-by: Oren Cohen <ocohen@redhat.com>

(cherry picked from commit faaa4a4202fc8b90ba8d4ed7807f153c95a9a127)

* Remove -oc-path flag from ginkgo execution

This flag no longer exists.

Signed-off-by: Oren Cohen <ocohen@redhat.com>

(cherry picked from commit 5901e88ef33e3689471a4696001503793951bd10)