### PR TITLE
Replace brew path with konflux

### DIFF
--- a/hack/test-cnv.sh
+++ b/hack/test-cnv.sh
@@ -9,8 +9,10 @@ echo "get matching kubevirt release from the build"
 VIRT_OPERATOR_IMAGE=$(oc get deployment virt-operator -n ${TARGET_NAMESPACE} -o jsonpath='{.spec.template.spec.containers[0].image}')
 
 if [ "$PRODUCTION_RELEASE" = "false" ]; then
-  # In case of a pre-release build, use the brew registry for the virt-operator image pullspec
-  VIRT_OPERATOR_IMAGE=${VIRT_OPERATOR_IMAGE//registry.redhat.io\/container-native-virtualization\//brew.registry.redhat.io\/rh-osbs\/container-native-virtualization-}
+  # In case of a pre-release build, use the quay registry (Konflux builds) for the virt-operator image pullspec
+  oldPrefix='registry.redhat.io/container-native-virtualization/'
+  newPrefix="quay.io/openshift-virtualization/konflux-builds/v${CNV_VERSION/./-}/" # NOTE: for Konflux builds 4.x -> v4-x
+  VIRT_OPERATOR_IMAGE="${VIRT_OPERATOR_IMAGE/${oldPrefix}/${newPrefix}}"
 fi
 KUBEVIRT_TAG=$(oc image info -a /tmp/authfile.new ${VIRT_OPERATOR_IMAGE} -o json --filter-by-os=linux/amd64 | jq '.config.config.Labels["upstream-version"]')
 KUBEVIRT_RELEASE=v$(echo ${KUBEVIRT_TAG} | awk -F '-' '{print $1}' | tr -d '"')


### PR DESCRIPTION
Resolve image path change, [see](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/75097/rehearse-75097-pull-ci-openshift-cnv-cnv-ci-release-4.21-e2e-deploy/2026553570953793536/artifacts/e2e-deploy/test/build-log.txt) 

```
++ oc get deployment virt-operator -n openshift-cnv -o 'jsonpath={.spec.template.spec.containers[0].image}'
+ VIRT_OPERATOR_IMAGE=registry.redhat.io/container-native-virtualization/virt-operator-rhel9@sha256:355f1c3ffe46dc1edd87875f12f352c36431b8acc2b705f6cb8b55ecb7416b7d
+ '[' false = false ']'
+ VIRT_OPERATOR_IMAGE=brew.registry.redhat.io/rh-osbs/container-native-virtualization-virt-operator-rhel9@sha256:355f1c3ffe46dc1edd87875f12f352c36431b8acc2b705f6cb8b55ecb7416b7d
++ oc image info -a /tmp/authfile.new brew.registry.redhat.io/rh-osbs/container-native-virtualization-virt-operator-rhel9@sha256:355f1c3ffe46dc1edd87875f12f352c36431b8acc2b705f6cb8b55ecb7416b7d -o json --filter-by-os=linux/amd64
++ jq '.config.config.Labels["upstream-version"]'
error: image "brew.registry.redhat.io/rh-osbs/container-native-virtualization-virt-operator-rhel9@sha256:355f1c3ffe46dc1edd87875f12f352c36431b8acc2b705f6cb8b55ecb7416b7d" not found: manifest unknown: manifest unknown
```