### PR TITLE
Use explicit versioned kind for HyperConverged

### DIFF
--- a/hack/dump-state.sh
+++ b/hack/dump-state.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 CMD=${CMD:-oc}
+HCO_KIND="hyperconvergeds.v1beta1.hco.kubevirt.io"
 
 function RunCmd {
     cmd=$@
@@ -64,11 +65,11 @@ echo $1
 RunCmd "${CMD} get pods -n ${CNV_NAMESPACE}"
 RunCmd "${CMD} get subscription -n ${CNV_NAMESPACE} -o yaml"
 RunCmd "${CMD} get deployment/hco-operator -n ${CNV_NAMESPACE} -o yaml"
-RunCmd "${CMD} get hyperconvergeds -n ${CNV_NAMESPACE} kubevirt-hyperconverged -o yaml"
+RunCmd "${CMD} get ${HCO_KIND} -n ${CNV_NAMESPACE} kubevirt-hyperconverged -o yaml"
 
-ShowOperatorSummary  hyperconvergeds.hco.kubevirt.io kubevirt-hyperconverged ${CNV_NAMESPACE}
+ShowOperatorSummary  ${HCO_KIND} kubevirt-hyperconverged ${CNV_NAMESPACE}
 
-RELATED_OBJECTS=`${CMD} get hyperconvergeds.hco.kubevirt.io kubevirt-hyperconverged -n ${CNV_NAMESPACE} -o go-template='{{range .status.relatedObjects }}{{if .namespace }}{{ printf "%s %s %s\n" .kind .name .namespace }}{{ else }}{{ printf "%s %s .\n" .kind .name }}{{ end }}{{ end }}'`
+RELATED_OBJECTS=`${CMD} get ${HCO_KIND} kubevirt-hyperconverged -n ${CNV_NAMESPACE} -o go-template='{{range .status.relatedObjects }}{{if .namespace }}{{ printf "%s %s %s\n" .kind .name .namespace }}{{ else }}{{ printf "%s %s .\n" .kind .name }}{{ end }}{{ end }}'`
 
 echo "${RELATED_OBJECTS}" | while read line; do 
 

--- a/hack/undeploy-cnv.sh
+++ b/hack/undeploy-cnv.sh
@@ -2,7 +2,9 @@
 
 set -euxo pipefail
 
-oc delete HyperConverged -n "${TARGET_NAMESPACE}" kubevirt-hyperconverged
+HCO_KIND="hyperconvergeds.v1beta1.hco.kubevirt.io"
+
+oc delete "${HCO_KIND}" -n "${TARGET_NAMESPACE}" kubevirt-hyperconverged
 oc delete OperatorGroup -n "${TARGET_NAMESPACE}" openshift-cnv-group
 oc delete Subscription -n "${TARGET_NAMESPACE}" kubevirt-hyperconverged
 oc delete ns "${TARGET_NAMESPACE}"

--- a/hack/wait-for-hco.sh
+++ b/hack/wait-for-hco.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-HCO_KIND="HyperConverged"
+HCO_KIND="hyperconvergeds.v1beta1.hco.kubevirt.io"
 HCO_CR="kubevirt-hyperconverged"
 
 echo "waiting for hco-operator deployment to be created"


### PR DESCRIPTION
Pin HyperConverged kind to v1beta1 (hyperconvergeds.v1beta1.hco.kubevirt.io) to prevent breakage when the v1 API is introduced.

Mirrors cnv-qe-automation MR !23077.